### PR TITLE
changing ember-cli-htmlbars version 

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
+    "@glimmer/component": "^1.0.4",
     "ember-cli-babel": "^7.26.6",
-    "ember-cli-htmlbars": "^5.7.1",
-    "@glimmer/component": "^1.0.4"
+    "ember-cli-htmlbars": "^6.0.1"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",


### PR DESCRIPTION
changing ember-cli-htmlbars version from 5.7.1 to 6.0.1